### PR TITLE
chore: added local config to docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ commitlint.config.json
 dist
 build
 reports
+config/local*


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                      |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
prevent local config from overriding default config in docker