### PR TITLE
chore: added PGAPPNAME environment variable (MAPCO-3796)

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
   DB_LOGGING: {{ .Values.env.db.logging | quote }}
   DB_SSL_ENABLE: {{ .Values.sharedData.db.sslEnabled | quote }}
   DB_SSL_REJECT_UNAUTHORIZED: {{ .Values.env.db.rejectUnauthorized | quote }}
+  PGAPPNAME: {{ $chartName }}
   {{ if .Values.env.tracing.enabled }}
   TELEMETRY_TRACING_ENABLED: 'true'
   TELEMETRY_TRACING_URL: {{ $tracingUrl }}


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
This environment variable is automatically picked up and assigned to "application_name" connection parameter by postgres. This parameter can be used to track which app is using each connection to the db.
